### PR TITLE
fix: Set post_base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,2 @@
 Recent blog posts:
 
-* [How to Actually Migrate Complex Systems in Infrastructure](http://kyle.cascade.familyhttps://kyle.cascade.family/posts/how-to-actually-migrate-complex-systems-in-infrastructure/)
-* [Saving Laptop Battery by Suspending Workspaces in i3](http://kyle.cascade.familyhttps://kyle.cascade.family/posts/saving-laptop-battery-by-suspending-workspaces-in-i3/)
-* [A Baby eInk Dashboard](http://kyle.cascade.familyhttps://kyle.cascade.family/posts/a-baby-eink-dashboard/)
-* [Automating a Roomba with ESPHome](http://kyle.cascade.familyhttps://kyle.cascade.family/posts/automating-a-roomba-with-esphome/)
-* [Hello World](http://kyle.cascade.familyhttps://kyle.cascade.family/posts/hello-world/)
-* [New Name, New Blog](http://www.xkyle.com/New-Name-New-Blog/)
-* [Why I'm Not an SRE](http://www.xkyle.com/Why-Im-Not-an-SRE/)
-* [The Incidental Complexity of Kubernetes](http://www.xkyle.com/The-Incidental-Complexity-of-Kubernetes/)
-* [WLED on a Ustellar RGB Flood 6 Pack](http://www.xkyle.com/WLED-on-a-Ustellar-RGB-Flood-6-Pack/)
-* [AWS re:Invent 2023 Talk: Iterating Faster on Stateful Services in the Cloud](http://www.xkyle.com/AWS-reInvent-2023-Talk-Iterating-Faster-on-Stateful-Services-in-the-Cloud/)
-
-![Build README](https://github.com/solarkennedy/solarkennedy/workflows/Build%20README/badge.svg)
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 Recent blog posts:
 
+* [How to Actually Migrate Complex Systems in Infrastructure](https://kyle.cascade.family/posts/how-to-actually-migrate-complex-systems-in-infrastructure/)
+* [Saving Laptop Battery by Suspending Workspaces in i3](https://kyle.cascade.family/posts/saving-laptop-battery-by-suspending-workspaces-in-i3/)
+* [A Baby eInk Dashboard](https://kyle.cascade.family/posts/a-baby-eink-dashboard/)
+* [Automating a Roomba with ESPHome](https://kyle.cascade.family/posts/automating-a-roomba-with-esphome/)
+* [Hello World](https://kyle.cascade.family/posts/hello-world/)
+* [New Name, New Blog](https://www.xkyle.com/New-Name-New-Blog/)
+* [Why I'm Not an SRE](https://www.xkyle.com/Why-Im-Not-an-SRE/)
+* [The Incidental Complexity of Kubernetes](https://www.xkyle.com/The-Incidental-Complexity-of-Kubernetes/)
+* [WLED on a Ustellar RGB Flood 6 Pack](https://www.xkyle.com/WLED-on-a-Ustellar-RGB-Flood-6-Pack/)
+* [AWS re:Invent 2023 Talk: Iterating Faster on Stateful Services in the Cloud](https://www.xkyle.com/AWS-reInvent-2023-Talk-Iterating-Faster-on-Stateful-Services-in-the-Cloud/)
+
+![Build README](https://github.com/solarkennedy/solarkennedy/workflows/Build%20README/badge.svg)

--- a/build_readme.py
+++ b/build_readme.py
@@ -12,12 +12,12 @@ def get_blog_rssxml(rss_url):
         return response.read()
 
 
-def print_blog_posts(blog_url):
+def print_blog_posts(blog_url, post_base_url = ""):
     rss_url = f"{blog_url}/index.xml"
     rssxml = get_blog_rssxml(rss_url)
     root = ET.fromstring(rssxml)
     for item in root[0].findall("item")[:5]:
-        url = f"{blog_url}{item.find('link').text}"
+        url = f"{post_base_url}{item.find('link').text}"
         text = item.find("title").text
         print(f"* [{text}]({url})")
 
@@ -33,5 +33,5 @@ def print_badge():
 if __name__ == "__main__":
     print(f"Recent blog posts:\n")
     print_blog_posts(CASCADE_BLOG_URL)
-    print_blog_posts(XKYLE_BLOG_URL)
+    print_blog_posts(XKYLE_BLOG_URL, XKYLE_BLOG_URL)
     print_badge()

--- a/build_readme.py
+++ b/build_readme.py
@@ -3,8 +3,8 @@ import xml
 import urllib.request
 import xml.etree.ElementTree as ET
 
-XKYLE_BLOG_URL = "http://www.xkyle.com"
-CASCADE_BLOG_URL = "http://kyle.cascade.family"
+XKYLE_BLOG_URL = "https://www.xkyle.com"
+CASCADE_BLOG_URL = "https://kyle.cascade.family"
 
 
 def get_blog_rssxml(rss_url):


### PR DESCRIPTION
The XMLs indexes return different formats of links:
- `https://www.xkyle.com` returns the path only
- `https://kyle.cascade.family` returns the domain and the path

This results in invalid URLs being printed in the README.

The proposed change adds a new optional parameter (`post_base_url`), that will prepend the link value returned in the index.xml

---

As a nice to have, blog URLs are updated to their https version